### PR TITLE
feat: Allow to specify the cause exception when creating a BpmnError

### DIFF
--- a/engine/src/main/java/org/camunda/bpm/engine/delegate/BpmnError.java
+++ b/engine/src/main/java/org/camunda/bpm/engine/delegate/BpmnError.java
@@ -53,6 +53,14 @@ public class BpmnError extends ProcessEngineException {
     setMessage(message);
   }
 
+	public BpmnError(String errorCode, String message, Throwable cause) {
+		this(errorCode, message + (cause != null ? "; details: " + cause.getMessage() : ""));
+	}
+
+	public BpmnError(String errorCode, Throwable cause) {
+		this(errorCode, cause.getMessage());
+	}
+
   protected void setErrorCode(String errorCode) {
     ensureNotEmpty("Error Code", errorCode);
     this.errorCode = errorCode;


### PR DESCRIPTION
This has two advantages:

1. The cause details are automatically included into the message text
2. When a BpmnError is thrown as a reaction on an application exception, from the catch block for the exception, sonar qube will not complain about the original exception not being logged or rethrown.